### PR TITLE
feedback on create-doc

### DIFF
--- a/client/src/document/forms/create.tsx
+++ b/client/src/document/forms/create.tsx
@@ -7,9 +7,13 @@ export default function DocumentCreate() {
   const navigate = useNavigate();
   const [savingError, setSavingError] = useState<Error | null>(null);
 
+  useEffect(() => {
+    document.title = "Create document";
+  }, []);
+
   async function handleCreate(data: DocumentData) {
     try {
-      const response = await fetch(`/_document`, {
+      const response = await fetch("/_document", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ locale, ...data }),

--- a/content/scripts/build.js
+++ b/content/scripts/build.js
@@ -659,7 +659,8 @@ class Builder {
     // But first, see if we can use the title from the last build.
     if (
       fs.existsSync(ALL_TITLES_JSON_FILEPATH) &&
-      !this.options.regenerateAllTitles
+      !this.options.regenerateAllTitles &&
+      !forceRegenerate
     ) {
       this.allTitles = new Map(
         Object.entries(

--- a/content/scripts/build.js
+++ b/content/scripts/build.js
@@ -878,9 +878,6 @@ class Builder {
         watcher.on("change", (path) => {
           onChange(path, source);
         });
-        // watcher.on("add", (path) => {
-        //   console.log("NEW PATH ADDED", path);
-        // });
         watcher.on("ready", () => {
           const watchedPaths = watcher.getWatched();
           const folders = Object.values(watchedPaths);


### PR DESCRIPTION
First there's some tiny nits. 

Most importantly, this change is actually not really part of the CRUD stuff you're adding. But I'm abusing this situation to squeeze in this important fix. 

To test:
* `yarn clean && yarn start`
* Wait for the watcher and all other things to start
* Create a new folder `mkdir content/files/en-us/glossary/brandspankingnew`
* Edit a new file `content/files/en-us/glossary/brandspankingnew/index.html` and in it put this:
```
---
slug: Glossary/Brandspankingnew
title: Brand spanking new
summary: BLa bla
---
<p>Hi!</p>
```
* Save it once (nothing happens and that's sad)
* Save it a second time to trigger the watcher

You should now see:
```
4:33:54 PM watchcontent.1 |  Building list of all titles took 12.2 seconds
4:33:55 PM watchcontent.1 |  processed: client/build/en-us/docs/glossary/brandspankingnew/index.html 12.2 seconds
```
in the console. 

Now, it's weird and annoying that this isn't being picked up immediately by the watcher when the file is added. We can dig into that "later". 

Another great example of this is
* Open some existing `index.html` like `emacs content/files/en-us/glossary/png/index.html`
* Edit the slug to a new/different slug. 

Again you should be seeing 
```
4:36:55 PM watchcontent.1 |  change in /Users/peterbe/dev/MOZILLA/MDN/yari/content/files/en-us/glossary/png
4:36:55 PM watchcontent.1 |  Parsed 20,000 popularities.
4:36:55 PM watchcontent.1 |  Building a list of ALL titles and URIs...
4:37:06 PM watchcontent.1 |  191 documents have a 'translation_of' that can actually not be found.
4:37:07 PM watchcontent.1 |  Building list of all titles took 12.0 seconds
4:37:07 PM watchcontent.1 |  processed: client/build/en-us/docs/glossary/png-223/index.html 12.1 seconds
```