### PR TITLE
Configurable builds

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -82,4 +82,6 @@ jobs:
           # functional tests have a gap in them but actually building
           # real content exposes it.
 
-          node content build --no-progressbar --files="${{ env.GIT_DIFF }}"
+          export BUILD_NO_PROGRESSBAR=true
+          export BUILD_FILES="${{ env.GIT_DIFF }}"
+          yarn build

--- a/build/build-options.js
+++ b/build/build-options.js
@@ -1,0 +1,75 @@
+require("dotenv").config();
+
+const {
+  FLAW_LEVELS,
+  DEFAULT_FLAW_LEVELS,
+  VALID_FLAW_CHECKS,
+} = require("./constants");
+
+// Core defaults
+const options = {
+  flawLevels: checkFlawLevels(DEFAULT_FLAW_LEVELS),
+};
+
+// Override based on env vars but only for options that are *not*
+// exclusive to building everyhing.
+function checkFlawLevels(flawChecks) {
+  const checks = flawChecks
+    .split(",")
+    .map((x) => x.trim())
+    .filter((x) => x)
+    .map((x) => x.split(":").map((s) => s.trim()));
+
+  // Check that it doesn't contain more than 1 wildcard,
+  // because that'd make no sense.
+  const wildcards = checks.filter((tuple) => tuple[0] === "*");
+  if (wildcards.length > 1) {
+    throw new Error(`Can only be 1 wild card (not: ${wildcards})`);
+  }
+
+  // Put any wildcards (e.g. '*:warn') first
+  checks.sort((a, b) => {
+    if (a[0] === "*" && b[0] !== "*") {
+      return -1;
+    } else if (a[0] !== "*" && b[0] === "*") {
+      return 1;
+    }
+    return 0;
+  });
+
+  const checked = new Map();
+
+  // Unless specified, set 'ignore' on all of them first.
+  for (const check of VALID_FLAW_CHECKS) {
+    checked.set(check, FLAW_LEVELS.IGNORE);
+  }
+
+  const levelValues = Object.values(FLAW_LEVELS);
+
+  for (const tuple of checks) {
+    if (tuple.length !== 2) {
+      throw new Error(`Not a tuple pair of 2 (${tuple})`);
+    }
+    const [identifier, level] = tuple;
+    if (!levelValues.includes(level)) {
+      throw new Error(`Invalid level: '${level}' (only ${levelValues})`);
+    }
+    if (identifier === "*") {
+      for (const check of VALID_FLAW_CHECKS) {
+        checked.set(check, level);
+      }
+    } else if (!VALID_FLAW_CHECKS.has(identifier)) {
+      throw new Error(
+        `Unrecognized flaw identifier: '${identifier}' (only ${[
+          ...VALID_FLAW_CHECKS,
+        ]})`
+      );
+    } else {
+      checked.set(identifier, level);
+    }
+  }
+
+  return checked;
+}
+
+module.exports = options;

--- a/build/build-options.js
+++ b/build/build-options.js
@@ -9,10 +9,10 @@ const {
   NO_PROGRESSBAR,
 } = require("./constants");
 
-module.exports = {
+const options = {
   flawLevels: parseFlawLevels(DEFAULT_FLAW_LEVELS),
   files: parseFiles(FILES),
-  foldersearch: parseFoldersearch(FOLDERSEARCH),
+  folderSearch: parseFoldersearch(FOLDERSEARCH),
   noProgressbar: NO_PROGRESSBAR,
 };
 
@@ -104,3 +104,5 @@ function parseFlawLevels(flawChecks) {
 
   return checked;
 }
+
+module.exports = options;

--- a/build/constants.js
+++ b/build/constants.js
@@ -29,7 +29,9 @@ const DEFAULT_FLAW_LEVELS = process.env.BUILD_FLAW_LEVELS || "*:warn";
 
 const FILES = process.env.BUILD_FILES || "";
 const FOLDERSEARCH = process.env.BUILD_FOLDERSEARCH || "";
-const NO_PROGRESSBAR = JSON.parse(process.env.BUILD_NO_PROGRESSBAR || "false");
+const NO_PROGRESSBAR = Boolean(
+  JSON.parse(process.env.BUILD_NO_PROGRESSBAR || process.env.CI || "false")
+);
 
 module.exports = {
   DEFAULT_FLAW_LEVELS,

--- a/build/constants.js
+++ b/build/constants.js
@@ -5,9 +5,9 @@ require("dotenv").config({
 });
 
 const FLAW_LEVELS = Object.freeze({
-  WARN: "warn",
-  IGNORE: "ignore",
   ERROR: "error",
+  IGNORE: "ignore",
+  WARN: "warn",
 });
 
 // These names need to match what we have in the code where we have various
@@ -27,8 +27,15 @@ const VALID_FLAW_CHECKS = new Set([
 // TODO (far future): Switch to "error" when number of flaws drops.
 const DEFAULT_FLAW_LEVELS = process.env.BUILD_FLAW_LEVELS || "*:warn";
 
+const FILES = process.env.BUILD_FILES || "";
+const FOLDERSEARCH = process.env.BUILD_FOLDERSEARCH || "";
+const NO_PROGRESSBAR = JSON.parse(process.env.BUILD_NO_PROGRESSBAR || "false");
+
 module.exports = {
-  VALID_FLAW_CHECKS,
-  FLAW_LEVELS,
   DEFAULT_FLAW_LEVELS,
+  FILES,
+  FLAW_LEVELS,
+  FOLDERSEARCH,
+  NO_PROGRESSBAR,
+  VALID_FLAW_CHECKS,
 };

--- a/build/index.js
+++ b/build/index.js
@@ -24,6 +24,7 @@ const {
 const { addBreadcrumbData } = require("./document-utils");
 const { injectFlaws } = require("./flaws");
 const cheerio = require("./monkeypatched-cheerio");
+const options = require("./build-options");
 
 const BUILD_OUT_ROOT = path.join(__dirname, "..", "client", "build");
 
@@ -105,8 +106,6 @@ function injectSource(doc, folder) {
   };
 }
 
-const options = { flawLevels: new Map() };
-
 async function buildDocument(document) {
   const { metadata, fileInfo } = document;
 
@@ -129,7 +128,6 @@ async function buildDocument(document) {
         flaw.line += fileInfo.frontMatterOffset - 1;
       }
     });
-
     if (options.flawLevels.get("macros") === FLAW_LEVELS.ERROR) {
       // Report and exit immediately on the first document with flaws.
       console.error(
@@ -322,7 +320,20 @@ async function buildDocuments() {
   }
 }
 
+// function poorMansCLI() {
+//   require("dotenv").config();
+//   // XXX We need some form of CLI that can override and amend the `options`
+//   // object imported from ./build-options.js
+//   const argv = process.argv.slice(2);
+//   console.log("BUILD OPTIONS ARE NOW:");
+//   console.log(options);
+// }
+
 if (require.main === module) {
+  console.log("CURRENT BUILD OPTIONS:");
+  console.log(options);
+  console.log("\n");
+
   buildDocuments().catch((error) => {
     console.error("error while building documents:", error);
   });

--- a/content/document.js
+++ b/content/document.js
@@ -216,9 +216,9 @@ const findByURL = memoize((url, fields = null) => {
 function findAll(
   { files, folderSearch } = { files: new Set(), folderSearch: null }
 ) {
-  if (!files instanceof Set) throw new Error("TypeError: 'files' not a Set");
+  if (!files instanceof Set) throw new TypeError("'files' not a Set");
   if (folderSearch && typeof folderSearch !== "string")
-    throw new Error("TypeError: 'folderSearch' not a string");
+    throw new TypeError("'folderSearch' not a string");
 
   // TODO: doesn't support archive content yet
   console.warn("Currently hardcoded to only build 'en-us'");

--- a/content/document.js
+++ b/content/document.js
@@ -214,11 +214,11 @@ const findByURL = memoize((url, fields = null) => {
 });
 
 function findAll(
-  { files, foldersearch } = { files: new Set(), foldersearch: null }
+  { files, folderSearch } = { files: new Set(), folderSearch: null }
 ) {
-  if (!files instanceof Set) throw new Error("TypeError: 'file' not a Set");
-  if (foldersearch && typeof foldersearch !== "string")
-    throw new Error("TypeError: 'file' not a Set");
+  if (!files instanceof Set) throw new Error("TypeError: 'files' not a Set");
+  if (folderSearch && typeof folderSearch !== "string")
+    throw new Error("TypeError: 'folderSearch' not a string");
 
   // TODO: doesn't support archive content yet
   console.warn("Currently hardcoded to only build 'en-us'");
@@ -228,11 +228,11 @@ function findAll(
       if (files.size) {
         return files.has(filepath);
       }
-      if (foldersearch) {
+      if (folderSearch) {
         return filepath
           .replace(CONTENT_ROOT, "")
           .replace(HTML_FILENAME, "")
-          .includes(foldersearch);
+          .includes(folderSearch);
       }
       return true;
     });

--- a/content/document.js
+++ b/content/document.js
@@ -215,7 +215,10 @@ const findByURL = memoize((url, fields = null) => {
 
 function findAll() {
   // TODO: doesn't support archive content yet
-  const filePaths = glob.sync(path.join(CONTENT_ROOT, "**", HTML_FILENAME));
+  console.warn("Currently hardcoded to only build 'en-us'");
+  const filePaths = glob.sync(
+    path.join(CONTENT_ROOT, "en-us", "**", HTML_FILENAME)
+  );
   return {
     count: filePaths.length,
     iter: function* () {

--- a/content/document.js
+++ b/content/document.js
@@ -213,12 +213,29 @@ const findByURL = memoize((url, fields = null) => {
   return document ? { contentRoot: CONTENT_ROOT, folder, document } : null;
 });
 
-function findAll() {
+function findAll(
+  { files, foldersearch } = { files: new Set(), foldersearch: null }
+) {
+  if (!files instanceof Set) throw new Error("TypeError: 'file' not a Set");
+  if (foldersearch && typeof foldersearch !== "string")
+    throw new Error("TypeError: 'file' not a Set");
+
   // TODO: doesn't support archive content yet
   console.warn("Currently hardcoded to only build 'en-us'");
-  const filePaths = glob.sync(
-    path.join(CONTENT_ROOT, "en-us", "**", HTML_FILENAME)
-  );
+  const filePaths = glob
+    .sync(path.join(CONTENT_ROOT, "en-us", "**", HTML_FILENAME))
+    .filter((filepath) => {
+      if (files.size) {
+        return files.has(filepath);
+      }
+      if (foldersearch) {
+        return filepath
+          .replace(CONTENT_ROOT, "")
+          .replace(HTML_FILENAME, "")
+          .includes(foldersearch);
+      }
+      return true;
+    });
   return {
     count: filePaths.length,
     iter: function* () {

--- a/server/index.js
+++ b/server/index.js
@@ -117,7 +117,7 @@ app.get("/*", async (req, res) => {
 
   const isJSONRequest = extraSuffix.endsWith(".json");
 
-  const document = await buildDocumentFromURL(lookupURL, isJSONRequest);
+  const document = await buildDocumentFromURL(lookupURL);
   if (!document) {
     // redirect resolving can take some time, so we only do it when there's no document
     // for the current route


### PR DESCRIPTION
Fixes #966

Basically, it's now making it possible to specify specific files and folders when building. Let's include everything that https://github.com/Gregoor/yari/pull/4 brought:

* `flawLevels` - can now be included in `yarn build` and `yarn start` by env vars. 
* `files` - is now respected, but via an env var instead of a CLI flag. This makes the PR Builds CI work again (in theory)
* `foldersearch` - by far the least important feature but something I often find myself using when hacking on doing mass-builds but don't want to have to wait for all 10k docs
* `noProgressbar` - very useful in CI and since `CI=true` is a "standard" in CI environments, we should probably consider `process.env.BUILD_NO_PROGRESSBAR || process.env.CI`