### PR TITLE
more robust extraction of redirect pairs

### DIFF
--- a/content/redirect.js
+++ b/content/redirect.js
@@ -38,7 +38,7 @@ const resolve = (() => {
       .readFileSync(redirectsFilePath, "utf-8")
       .split("\n")
       .slice(1, -1)
-      .map((line) => line.split("\t"));
+      .map((line) => line.trim().split(/\s+/));
     for (const [from, to] of redirectPairs) {
       redirects[from.toLowerCase()] = to;
     }


### PR DESCRIPTION
One of the functional tests (`content built bar page`) within `testing/tests/index.test.js` was failing because the last redirect pair in `testing/content/files/en-us/_redirects.txt` is separated by a space rather than a tab. I'm suggesting here that we split on whitespace so it's more robust. This PR fixes the `content built bar page` test within `testing/tests/index.test.js`.