### PR TITLE
fix puppeteer server auto start config

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -4,6 +4,7 @@
   "main": "index.js",
   "license": "MPL-2.0",
   "scripts": {
+    "start:no-watch": "node index.js",
     "start": "nodemon index.js --watch . --watch ../build --watch ../content --watch ../kumascript"
   },
   "dependencies": {

--- a/testing/jest-puppeteer.config.js
+++ b/testing/jest-puppeteer.config.js
@@ -1,10 +1,8 @@
 const serverExports = {};
 if (JSON.parse(process.env.TESTING_START_SERVER || "false")) {
   serverExports.server = {
-    // This is the .env file here inside the 'testing/' directory.
-    // This is needed so that the server that gets started get the right
-    // environment variables specifically for the functional test suite.
-    command: "ENV_FILE=.env node ../server/index.js",
+    command:
+      "cd .. && ENV_FILE=testing/.env yarn workspace server start:no-watch",
     port: 5000,
     host: "localhost",
     debug: true, // XXX Note sure that the harm is of having this on


### PR DESCRIPTION
I'm not sure why this started happening now, but when we use the `jest-puppeteer` server auto start/teardown functionality (set `TESTING_START_SERVER` to `true`), we get the following error:
```
Error: Cannot find module '.../yari/testing/document-watch.worker.js'
```

This PR fixes that, but perhaps there's a better approach?