### PR TITLE
fix building of live-sample pages from url

### DIFF
--- a/build/index.js
+++ b/build/index.js
@@ -245,7 +245,7 @@ async function buildLiveSamplePageFromURL(url) {
         sampleIDObject
       );
       if (liveSamplePage.flaw) {
-        throw liveSamplePage.flaw;
+        throw new Error(liveSamplePage.flaw.toString());
       }
       return liveSamplePage.html;
     }

--- a/build/index.js
+++ b/build/index.js
@@ -229,7 +229,7 @@ async function buildLiveSamplePageFromURL(url) {
   const [documentURL, sampleID] = url.split("/_samples_/");
   const document = Document.findByURL(documentURL);
   if (!document) {
-    return `unable to find ${documentURL}`;
+    throw new Error(`No document found for ${documentURL}`);
   }
   // Convert the lower-case sampleID we extract from the incoming URL into
   // the actual sampleID object with the properly-cased live-sample ID.
@@ -245,12 +245,12 @@ async function buildLiveSamplePageFromURL(url) {
         sampleIDObject
       );
       if (liveSamplePage.flaw) {
-        return liveSamplePage.flaw.errorMessage;
+        throw liveSamplePage.flaw;
       }
       return liveSamplePage.html;
     }
   }
-  return `unable to find live-sample "${sampleID}" within ${documentURL}`;
+  throw new Error(`No live-sample "${sampleID}" found within ${documentURL}`);
 }
 
 module.exports = {

--- a/server/index.js
+++ b/server/index.js
@@ -96,7 +96,11 @@ app.get("/*", async (req, res) => {
   }
 
   if (req.url.includes("/_samples_/")) {
-    return res.send(await buildLiveSamplePageFromURL(req.url));
+    try {
+      return res.send(await buildLiveSamplePageFromURL(req.url));
+    } catch (e) {
+      return res.status(404).send(e.errorMessage || e.message);
+    }
   }
 
   if (!req.url.includes("/docs/")) {

--- a/server/index.js
+++ b/server/index.js
@@ -99,7 +99,7 @@ app.get("/*", async (req, res) => {
     try {
       return res.send(await buildLiveSamplePageFromURL(req.url));
     } catch (e) {
-      return res.status(404).send(e.errorMessage || e.message);
+      return res.status(404).send(e.toString());
     }
   }
 


### PR DESCRIPTION
This PR fixes the building of live-sample pages by URL. Currently, when in functional mode and you visit http://localhost:5000/en-US/docs/Learn/CSS/CSS_layout/Introduction, you'll see empty live-sample `iframe`'s:

<img width="706" alt="image" src="https://user-images.githubusercontent.com/3743693/88755188-68251300-d115-11ea-9247-ef727c23444b.png">

With this PR, you'll see this:

<img width="710" alt="image" src="https://user-images.githubusercontent.com/3743693/88755078-2005f080-d115-11ea-89bb-d31ad93ffd00.png">
