### PR TITLE
sort searchindex before dumping

### DIFF
--- a/build/cli.js
+++ b/build/cli.js
@@ -109,6 +109,7 @@ async function buildDocuments() {
     );
   }
 
+  searchIndex.sort();
   for (const [locale, items] of Object.entries(searchIndex.getItems())) {
     fs.writeFileSync(
       path.join(BUILD_OUT_ROOT, locale.toLowerCase(), "search-index.json"),


### PR DESCRIPTION
It looks a bit naked when it sits there but it works. 

```
▶ cat client/build/en-us/search-index.json| jq | head -5
[
  {
    "title": "Specificity",
    "url": "/en-US/docs/Web/CSS/Specificity"
  },
```